### PR TITLE
feat: add recency boost to search scoring

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,285 +1,80 @@
-# SPEC: Generic Retrieval Skill — Incremental Indexing & Hybrid Search
+# Recency Boost for Retrieval Search
 
-**Status:** 🟡 In Progress
-**Repo:** `~/personal/retrieval-skill` → `github.com/c-h-/retrieval-skill` (private)
-**Branch:** `main`
+## Goal
+Add time-aware scoring to search results so recent content is preferred over stale content, with semantic relevance still dominant.
 
----
+## Current State
+- `files` table has `mtime_ms` and `metadata` (JSON) columns
+- `metadata` already contains timestamps from sources:
+  - **Notion**: `created_time`, `last_edited_time` (ISO strings)
+  - **Linear**: `createdAt`, `updatedAt` (ISO strings)
+  - **Slack**: `exported_at` per channel (not per-message — gap, but usable)
+  - **Mono**: `last-reviewed` (date string), plus filesystem `mtime_ms`
+- `chunks` table has no timestamp column
+- Search scoring is pure semantic (vector + FTS hybrid with RRF fusion)
 
-## Overview
+## Changes Required
 
-Build a production-quality generic retrieval system: incremental indexing of any directory into a SQLite vector store, with hybrid FTS5 + cosine search. This will become an OpenClaw skill for autonomous agent search across Slack, Linear, Gmail, Notion, and any other indexed content.
+### 1. Schema Migration (schema.mjs)
+- Bump `SCHEMA_VERSION` to 4
+- Add `content_timestamp_ms INTEGER` column to `chunks` table (nullable)
+- Migration: `ALTER TABLE chunks ADD COLUMN content_timestamp_ms INTEGER` for existing DBs
+- Backward compatible: null = no recency boost applied to that chunk
 
-**Key decisions from Charlie:**
-- Use the **best quality open-weights embedding model** (not BGE-small). Research leaderboard and pick the best that runs locally on Apple Silicon (512GB RAM Mac Studio).
-- Each saas-mirror adapter gets its own **top-level index** (e.g., `linear`, `slack`, `gog`, `notion`) — not one unified index.
-- **Multi-index search** supported: `retrieve search --index linear,slack "auth flow"`
-- Triggering/scheduling will be figured out later — keep indexing and search **loosely coupled** from saas-mirror.
-- This will be an **OpenClaw skill** as its primary purpose — agents call `retrieve search` autonomously.
-- Start with best quality model. We have a powerful machine.
+### 2. Timestamp Extraction (chunker.mjs)
+Add `extractContentTimestamp(frontmatter, mtimeMs)` function:
+- Priority order for frontmatter fields: `last_edited_time` > `updatedAt` > `updated_at` > `last_edited` > `createdAt` > `created_at` > `created_time` > `date` > `last-reviewed`
+- Parse ISO strings and date strings to epoch ms
+- Fall back to `mtimeMs` (file mtime) if no frontmatter date found
+- Return `number | null`
 
----
+### 3. Indexer (index.mjs)
+- Call `extractContentTimestamp()` during indexing
+- Pass the timestamp to chunk insertion
+- All chunks from a file share the same `content_timestamp_ms` (file-level granularity is fine)
 
-## 1. Prior Art (Reference Implementation)
+### 4. Search Scoring (search.mjs)
+Add recency boost to final scoring:
+```js
+function recencyBoost(contentTimestampMs, halfLifeDays = 90) {
+  if (!contentTimestampMs) return 1.0; // no timestamp = no boost/penalty
+  const ageDays = (Date.now() - contentTimestampMs) / 86_400_000;
+  return 1 / (1 + ageDays / halfLifeDays);
+}
 
-The existing prototype lives at `~/.openclaw/skills/retrieve/` — a working but limited system built for cookbook recipes. See the old `SPEC-retrieve.md` in saas-mirror for full gap analysis. Key pieces to carry forward:
-- SQLite + FTS5 + vectors as BLOBs (zero-infra, portable)
-- Hybrid search concept (FTS + cosine)
-- Local ONNX model inference via `@xenova/transformers`
-
-The existing prototype's model (`Xenova/bge-small-en-v1.5`, 33MB) and scripts should be referenced but NOT copied. Build fresh.
-
----
-
-## 2. Phase 0: Embedding Model Research
-
-Before writing code, research and select the best local embedding model:
-
-- [x] Check MTEB leaderboard for top open-weights embedding models
-- [x] Filter for models that run on Apple Silicon (ONNX or MLX)
-- [x] Compare: dimensions, max tokens, MTEB retrieval score, model size
-- [x] Consider: `nomic-embed-text-v1.5`, `bge-large-en-v1.5`, `e5-large-v2`, `gte-large`, `mxbai-embed-large`, or newer models
-- [x] Check if `@xenova/transformers` supports the chosen model (ONNX), or if we need `mlx` runtime
-- [x] Document the choice and reasoning in this spec before proceeding
-
-**Constraint:** Must run locally, no API calls. Quality > speed (we have a Mac Studio).
-
-### Model Decision: `Snowflake/snowflake-arctic-embed-l`
-
-| Property | Value |
-|---|---|
-| **HuggingFace ID** | `Snowflake/snowflake-arctic-embed-l` |
-| **Parameters** | 335M |
-| **Dimensions** | 1024 |
-| **Max Tokens** | 512 |
-| **MTEB Retrieval nDCG@10** | **55.98** (highest among ONNX-compatible models) |
-| **Runtime** | `@huggingface/transformers` (ONNX) |
-| **Pooling** | CLS token |
-| **Query Prefix** | `"Represent this sentence for searching relevant passages: "` |
-| **Document Prefix** | None |
-| **License** | Apache-2.0 |
-
-**Why this model:**
-1. Highest retrieval-specific score (55.98 nDCG@10) among all models with confirmed transformers.js/ONNX compatibility
-2. ONNX weights available directly in the HuggingFace repo, tagged for transformers.js
-3. 1024-dim embeddings provide rich semantic representations
-4. 512 max tokens aligns perfectly with our chunking strategy
-5. Apache-2.0 license, fully permissive
-
-**Runners-up considered:** mxbai-embed-large-v1 (54.39), bge-large-en-v1.5 (54.29), nomic-embed-text-v1.5 (~49). Arctic-embed-l-v2.0 was rejected due to a known transformers.js bug (issue #1326) and slightly lower retrieval score.
-
----
-
-## 3. Schema (SQLite)
-
-```sql
-CREATE TABLE IF NOT EXISTS meta (
-  key TEXT PRIMARY KEY,
-  value TEXT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS files (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  path TEXT NOT NULL UNIQUE,
-  content_hash TEXT NOT NULL,
-  size INTEGER NOT NULL,
-  mtime_ms INTEGER NOT NULL,
-  indexed_at TEXT NOT NULL,
-  metadata TEXT  -- JSON: frontmatter fields, source info
-);
-
-CREATE TABLE IF NOT EXISTS chunks (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
-  chunk_index INTEGER NOT NULL,
-  content TEXT NOT NULL,
-  embedding BLOB NOT NULL,
-  content_hash TEXT NOT NULL,
-  section_context TEXT,  -- e.g., "Issue ENG-1234 | Comments"
-  UNIQUE(file_id, chunk_index)
-);
-
-CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
-  content, file_path, content_rowid='id'
-);
-
-CREATE INDEX IF NOT EXISTS idx_files_path ON files(path);
-CREATE INDEX IF NOT EXISTS idx_chunks_hash ON chunks(content_hash);
+// Applied as:
+finalScore = semanticScore * (1 - recencyWeight + recencyWeight * recencyBoost);
 ```
 
----
+- Default `recencyWeight`: 0.15 (semantic still dominates)
+- Default `halfLifeDays`: 90
+- Both configurable via search options
 
-## 4. Incremental Indexing
+### 5. CLI (cli.mjs)
+- Add `--recency-weight <n>` option (default 0.15, 0 to disable)
+- Add `--half-life <days>` option (default 90)
+- Display timestamp in results when available: `[0.83 | 2d ago]` or `[0.83 | 3mo ago]`
 
-Change detection per file:
-1. **mtime fast path** — unchanged mtime → SKIP
-2. **SHA-256 content hash** — mtime changed but content same → update mtime, SKIP
-3. **Content changed** → delete old chunks (CASCADE), re-chunk, embed new chunks, insert
-4. **Dead file pruning** — DB entries for files no longer on disk get deleted
+### 6. Format Output
+Update `formatResults()` to show relative age next to score when `content_timestamp_ms` is present.
 
-Content-addressed chunk caching: `content_hash = SHA-256(chunk_content + model_id)`. Same content with same model = reuse embedding.
+## Non-Goals
+- Per-message Slack timestamps (separate indexer enhancement)
+- Re-indexing existing data (user runs `retrieval-skill index --reindex` manually)
 
----
+## Implementation Status
 
-## 5. Markdown-Aware Chunking
+All sections implemented in `feat/recency-boost` branch:
 
-1. Parse YAML frontmatter → extract as file metadata (NOT included in chunks)
-2. Split on markdown headers (`##`, `###`) as natural section boundaries
-3. Within sections, split on paragraph boundaries (`\n\n`)
-4. Merge small paragraphs up to target chunk size (~512 tokens for the chosen model's max)
-5. Oversized sections: split at sentence boundaries with overlap
-6. Each chunk gets a **context prefix** from document title + section header
+- **Schema (schema.mjs)**: `SCHEMA_VERSION` bumped to 4. `content_timestamp_ms INTEGER` added to `chunks` table. v3→v4 migration adds column to existing DBs via `ALTER TABLE`.
+- **Timestamp extraction (chunker.mjs)**: `extractContentTimestamp(frontmatter, mtimeMs)` exported. Parses ISO strings, date strings, and numeric epoch values. Falls back to file mtime.
+- **Indexer (index.mjs)**: Calls `extractContentTimestamp()` during indexing; all chunks from a file share the same `content_timestamp_ms`.
+- **Search scoring (search.mjs)**: `recencyBoost()` and `relativeAge()` exported. Final score: `semanticScore * (1 - recencyWeight + recencyWeight * boost)`. Defaults: weight 0.15, half-life 90 days.
+- **CLI (cli.mjs)**: `--recency-weight <n>` and `--half-life <days>` options added to `search` command.
+- **Formatted output**: Shows `[0.83 | 2d ago]` when `content_timestamp_ms` is present.
 
----
-
-## 6. CLI Interface
-
-```bash
-# Unified CLI
-node src/cli.mjs <command> [options]
-
-# Index a directory
-retrieve index <directory> [--name <index-name>] [--model <model-alias>]
-
-# Search (single or multi-index)
-retrieve search <query> --index <name>[,<name>...] [--top-k <n>] [--threshold <score>] [--json]
-
-# List all indexes
-retrieve list
-
-# Show index status
-retrieve status <index-name>
-
-# Delete an index
-retrieve delete <index-name>
-```
-
-**Index naming convention for saas-mirror:**
-```bash
-retrieve index ~/personal/saas-mirror/data/linear --name linear
-retrieve index ~/personal/saas-mirror/data/slack --name slack
-retrieve index ~/personal/saas-mirror/data/gog --name gog
-retrieve index ~/personal/saas-mirror/data/notion --name notion
-```
-
-**Multi-index search:**
-```bash
-retrieve search "auth token refresh" --index linear,slack,gog
-retrieve search "meeting notes" --index slack --top-k 10
-```
-
----
-
-## 7. Search Pipeline
-
-```
-1. Embed query with index's model
-2. FTS5 keyword search → top 100 candidates per index
-3. Cosine similarity on FTS candidates → re-rank
-4. Pure vector scan on recent/random sample → catch semantic-only matches
-5. Merge across indexes, deduplicate, final top-K
-6. Return: content, score, file path, section context, metadata
-```
-
-Output format (default: human-readable, `--json` for programmatic):
-```
-[0.847] linear/issues/ENG/ENG-1234.md § Comments
-  "The auth token refresh was failing because the middleware..."
-  
-[0.823] slack/channels/engineering/messages.md § 2026-02-10
-  "Charlie mentioned we need to handle the OAuth refresh..."
-```
-
----
-
-## 8. Project Structure
-
-```
-~/personal/retrieval-skill/
-├── src/
-│   ├── cli.mjs          # CLI dispatcher
-│   ├── index.mjs        # Indexing engine
-│   ├── search.mjs       # Search engine  
-│   ├── chunker.mjs      # Markdown-aware chunking
-│   ├── embedder.mjs     # Model loading + embedding
-│   ├── schema.mjs       # SQLite schema + migrations
-│   └── utils.mjs        # Hashing, file walking, etc.
-├── __tests__/
-│   ├── chunker.test.mjs
-│   ├── index.test.mjs
-│   ├── search.test.mjs
-│   └── fixtures/        # Sample .md files for testing
-├── indexes/             # SQLite index DBs (gitignored)
-├── models/              # ONNX/MLX model files (gitignored)
-├── SPEC.md
-├── README.md
-├── package.json
-├── .gitignore
-└── vitest.config.mjs    # or similar test config
-```
-
----
-
-## 9. Implementation Phases
-
-### Phase 0: Model Research (~30 min)
-- [ ] Research MTEB leaderboard for best open-weights embedding model
-- [ ] Verify it runs locally (ONNX via @xenova/transformers, or MLX)
-- [ ] Document choice in this spec
-- [ ] Download model
-
-### Phase 1: Core Infrastructure (~3 hrs)
-- [ ] Project setup: package.json, dependencies, .gitignore
-- [ ] SQLite schema with migrations
-- [ ] File walker (recursive, filtered by extension)
-- [ ] Content hashing (SHA-256)
-- [ ] Incremental change detection
-- [ ] Embedder module (model loading, batch embedding)
-
-### Phase 2: Chunking (~2 hrs)
-- [ ] YAML frontmatter parser
-- [ ] Markdown header splitter
-- [ ] Paragraph-boundary chunker with merge
-- [ ] Context prefix generation
-- [ ] Tests with fixture files
-
-### Phase 3: Indexing CLI (~2 hrs)
-- [ ] `index` command: walk → detect changes → chunk → embed → store
-- [ ] `list` command
-- [ ] `status` command  
-- [ ] `delete` command
-- [ ] Progress reporting during indexing
-
-### Phase 4: Search (~2 hrs)
-- [ ] `search` command with FTS pre-filter → cosine re-rank
-- [ ] Multi-index search (merge results across DBs)
-- [ ] `--json` output for programmatic use
-- [ ] `--threshold` filtering
-- [ ] Human-readable output with context
-
-### Phase 5: E2E Testing (~2 hrs)
-- [ ] Index `~/personal/saas-mirror/data/linear` → verify index created
-- [ ] Index `~/personal/saas-mirror/data/slack` → verify
-- [ ] Search across both: `retrieve search "auth" --index linear,slack`
-- [ ] Incremental test: modify a file, re-index, verify only that file re-embedded
-- [ ] Unit tests for chunker, hasher, change detection
-- [ ] Document results in README
-
-### Phase 6: Ship (~30 min)
-- [ ] README with full usage docs
-- [ ] Commit and push to `c-h-/retrieval-skill`
-- [ ] Verify tests pass
-
----
-
-## 10. Key Context
-
-- **Repo:** `~/personal/retrieval-skill` → `github.com/c-h-/retrieval-skill` (private)
-- **Git author:** `Doink (OpenClaw) <charlie+doink@kindo.ai>` + `Co-Authored-By: Charlie Hulcher <charlie@kindo.ai>`
-- **Use `gh-me`** (NOT `gh`) for any GitHub CLI operations
-- **Test data:** `~/personal/saas-mirror/data/{linear,slack,gog,notion}` — use for E2E testing
-- **Reference implementation:** `~/.openclaw/skills/retrieve/` — read for patterns but build fresh
-- **Machine:** Mac Studio, Apple Silicon, 512GB RAM — use best quality model
-- **Node.js ESM** — use `.mjs` extensions, `import` not `require`
-- **Dependencies:** `better-sqlite3`, `@xenova/transformers` (or MLX if better model needs it), `yaml`, `commander`, `vitest`
-- **After this works E2E:** We'll install it as an OpenClaw skill at `~/.openclaw/skills/retrieve/`
+## Testing
+- `__tests__/recency.test.mjs`: 27 tests covering `extractContentTimestamp()`, `recencyBoost()`, and `relativeAge()`
+- Unit tests for `extractContentTimestamp()` with various frontmatter shapes (Notion, Linear, Slack, Mono, snake_case, numeric epochs, invalid dates, priority ordering)
+- Unit tests for `recencyBoost()` math (null=1.0, half-life precision, future timestamps, scoring formula)
+- Unit tests for `relativeAge()` formatting (today, days, months, years)

--- a/__tests__/recency.test.mjs
+++ b/__tests__/recency.test.mjs
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { extractContentTimestamp } from '../src/chunker.mjs';
+import { recencyBoost, relativeAge } from '../src/search.mjs';
+
+// ── extractContentTimestamp ──────────────────────────────────────────
+
+describe('extractContentTimestamp', () => {
+  it('picks last_edited_time (Notion) over other fields', () => {
+    const fm = {
+      last_edited_time: '2024-06-15T10:00:00.000Z',
+      createdAt: '2024-01-01T00:00:00.000Z',
+    };
+    expect(extractContentTimestamp(fm)).toBe(new Date('2024-06-15T10:00:00.000Z').getTime());
+  });
+
+  it('picks updatedAt (Linear)', () => {
+    const fm = { updatedAt: '2025-01-20T08:30:00Z' };
+    expect(extractContentTimestamp(fm)).toBe(new Date('2025-01-20T08:30:00Z').getTime());
+  });
+
+  it('picks updated_at (snake_case variant)', () => {
+    const fm = { updated_at: '2025-03-01' };
+    const result = extractContentTimestamp(fm);
+    expect(result).toBe(new Date('2025-03-01').getTime());
+  });
+
+  it('picks createdAt when no update field present', () => {
+    const fm = { createdAt: '2024-12-01T00:00:00Z' };
+    expect(extractContentTimestamp(fm)).toBe(new Date('2024-12-01T00:00:00Z').getTime());
+  });
+
+  it('picks date field', () => {
+    const fm = { date: '2024-08-15' };
+    expect(extractContentTimestamp(fm)).toBe(new Date('2024-08-15').getTime());
+  });
+
+  it('picks last-reviewed (Mono)', () => {
+    const fm = { 'last-reviewed': '2025-02-01' };
+    expect(extractContentTimestamp(fm)).toBe(new Date('2025-02-01').getTime());
+  });
+
+  it('falls back to mtimeMs when no frontmatter date', () => {
+    const fm = { title: 'No timestamps here' };
+    expect(extractContentTimestamp(fm, 1700000000000)).toBe(1700000000000);
+  });
+
+  it('falls back to mtimeMs when frontmatter is null', () => {
+    expect(extractContentTimestamp(null, 1700000000000)).toBe(1700000000000);
+  });
+
+  it('returns null when no frontmatter and no mtime', () => {
+    expect(extractContentTimestamp(null)).toBeNull();
+    expect(extractContentTimestamp(null, null)).toBeNull();
+  });
+
+  it('handles epoch-second numeric timestamps', () => {
+    const fm = { date: 1700000000 }; // seconds
+    expect(extractContentTimestamp(fm)).toBe(1700000000000);
+  });
+
+  it('handles epoch-ms numeric timestamps', () => {
+    const fm = { date: 1700000000000 }; // ms
+    expect(extractContentTimestamp(fm)).toBe(1700000000000);
+  });
+
+  it('skips invalid date strings and falls back', () => {
+    const fm = { last_edited_time: 'not-a-date', createdAt: '2025-01-01T00:00:00Z' };
+    expect(extractContentTimestamp(fm)).toBe(new Date('2025-01-01T00:00:00Z').getTime());
+  });
+
+  it('respects priority order: last_edited_time > updatedAt', () => {
+    const fm = {
+      updatedAt: '2025-06-01T00:00:00Z',
+      last_edited_time: '2025-07-01T00:00:00Z',
+    };
+    expect(extractContentTimestamp(fm)).toBe(new Date('2025-07-01T00:00:00Z').getTime());
+  });
+
+  it('floors mtimeMs to integer', () => {
+    expect(extractContentTimestamp(null, 1700000000123.456)).toBe(1700000000123);
+  });
+});
+
+// ── recencyBoost ─────────────────────────────────────────────────────
+
+describe('recencyBoost', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns 1.0 for null timestamp', () => {
+    expect(recencyBoost(null)).toBe(1.0);
+    expect(recencyBoost(undefined)).toBe(1.0);
+  });
+
+  it('returns 1.0 for content from right now', () => {
+    expect(recencyBoost(Date.now())).toBe(1.0);
+  });
+
+  it('returns ~0.5 at half-life age', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    const halfLife = 90;
+    const ts = now - halfLife * 86_400_000;
+    const boost = recencyBoost(ts, halfLife);
+    expect(boost).toBeCloseTo(0.5, 2);
+  });
+
+  it('returns ~0.333 at 2x half-life', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    const halfLife = 90;
+    const ts = now - 2 * halfLife * 86_400_000;
+    const boost = recencyBoost(ts, halfLife);
+    expect(boost).toBeCloseTo(1 / 3, 2);
+  });
+
+  it('returns higher value for newer content', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    const recent = now - 7 * 86_400_000;  // 7 days
+    const old = now - 365 * 86_400_000;   // 1 year
+    expect(recencyBoost(recent, 90)).toBeGreaterThan(recencyBoost(old, 90));
+  });
+
+  it('applies the scoring formula correctly', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    const semanticScore = 0.8;
+    const recencyWeight = 0.15;
+    const ts = now - 90 * 86_400_000; // half-life age
+    const boost = recencyBoost(ts, 90);
+    const finalScore = semanticScore * (1 - recencyWeight + recencyWeight * boost);
+    // boost ≈ 0.5, so factor = 1 - 0.15 + 0.15 * 0.5 = 0.925
+    expect(finalScore).toBeCloseTo(0.8 * 0.925, 3);
+  });
+
+  it('returns 1.0 for future timestamps', () => {
+    const future = Date.now() + 86_400_000;
+    expect(recencyBoost(future)).toBe(1.0);
+  });
+});
+
+// ── relativeAge ──────────────────────────────────────────────────────
+
+describe('relativeAge', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null for null/undefined', () => {
+    expect(relativeAge(null)).toBeNull();
+    expect(relativeAge(undefined)).toBeNull();
+  });
+
+  it('returns "today" for same-day timestamp', () => {
+    expect(relativeAge(Date.now() - 3600_000)).toBe('today');
+  });
+
+  it('returns "1d ago" for yesterday', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    expect(relativeAge(now - 86_400_000)).toBe('1d ago');
+  });
+
+  it('returns days for < 30 days', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    expect(relativeAge(now - 15 * 86_400_000)).toBe('15d ago');
+  });
+
+  it('returns months for 30-365 days', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    expect(relativeAge(now - 90 * 86_400_000)).toBe('3mo ago');
+  });
+
+  it('returns years for > 365 days', () => {
+    const now = Date.now();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    expect(relativeAge(now - 400 * 86_400_000)).toBe('1y ago');
+  });
+});

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -46,14 +46,18 @@ program
   .option('--top-k <n>', 'Number of results', '10')
   .option('--threshold <score>', 'Minimum score threshold', '0')
   .option('--mode <mode>', 'Search mode: text (default), vision, hybrid', 'text')
+  .option('--recency-weight <n>', 'Recency weight (0 to disable, default 0.15)', '0.15')
+  .option('--half-life <days>', 'Recency half-life in days (default 90)', '90')
   .option('--json', 'Output as JSON')
   .action(async (query, opts) => {
     const indexNames = opts.index.split(',').map(s => s.trim());
     const topK = parseInt(opts.topK, 10);
     const threshold = parseFloat(opts.threshold);
     const mode = opts.mode;
+    const recencyWeight = parseFloat(opts.recencyWeight);
+    const halfLifeDays = parseFloat(opts.halfLife);
 
-    const results = await search(query, indexNames, { topK, threshold, mode });
+    const results = await search(query, indexNames, { topK, threshold, mode, recencyWeight, halfLifeDays });
 
     if (opts.json) {
       console.log(formatResultsJson(results));


### PR DESCRIPTION
Adds time-aware scoring to search results. Content timestamp extracted from frontmatter (9 field types) with file mtime fallback. Exponential decay formula with configurable weight (--recency-weight, default 0.15) and half-life (--half-life, default 90 days). 27 tests passing.