### PR TITLE
feat: source code indexing for mono repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,7 @@ GMAIL_REFRESH_TOKEN=
 # ─── GOG Connector (Gmail via gog CLI) ───
 GOG_ACCOUNT=
 # GOG_PATH=gog
+
+# ─── Git Repo Indexing ───
+# Semicolon-separated name:path pairs for git repos to pull and index
+# RETRIEVE_GIT_REPOS="myrepo:/path/to/repo;docs:/path/to/docs"

--- a/scheduling/README.md
+++ b/scheduling/README.md
@@ -18,7 +18,19 @@ bash scheduling/setup.sh uninstall
 
 `scheduling/sync-and-index.sh`:
 1. Loads `.env.local` / `.env`
-2. Runs `node src/cli.mjs mirror sync`
+2. Runs `node src/cli.mjs mirror sync` (SaaS connectors)
 3. Indexes each available adapter directory (`slack`, `notion`, `linear`, `gog`)
+4. Pulls and indexes any git repos configured via `RETRIEVE_GIT_REPOS`
 
 Default interval is 30 minutes via launchd.
+
+## Git Repo Indexing
+
+To index local git repositories alongside SaaS data, set `RETRIEVE_GIT_REPOS` in `.env.local`:
+
+```bash
+# Semicolon-separated name:path pairs
+RETRIEVE_GIT_REPOS="myrepo:/path/to/repo;docs:/path/to/docs-repo"
+```
+
+Each repo is `git pull --ff-only`'d and then indexed under the given name. The indexer is incremental — only changed files are re-embedded on subsequent runs.

--- a/scheduling/sync-and-index.sh
+++ b/scheduling/sync-and-index.sh
@@ -71,13 +71,28 @@ for adapter in slack notion linear; do
   fi
 done
 
-# Mono repo code index
-MONO_DIR="$HOME/code/mono"
-if [ -d "$MONO_DIR/.git" ]; then
-  echo "$LOG_PREFIX Pulling latest mono main..."
-  git -C "$MONO_DIR" pull --ff-only 2>&1 || echo "$LOG_PREFIX Warning: mono git pull failed"
-  echo "$LOG_PREFIX Indexing mono -> mono"
-  node src/cli.mjs index "$MONO_DIR" --name mono 2>&1 || echo "$LOG_PREFIX Warning: mono indexing failed"
+# Git repo indexing
+# RETRIEVE_GIT_REPOS is a semicolon-separated list of name:path pairs.
+# Example: RETRIEVE_GIT_REPOS="mono:$HOME/code/mono;docs:$HOME/projects/docs"
+# Each repo is pulled (ff-only) and indexed under the given name.
+if [ -n "${RETRIEVE_GIT_REPOS:-}" ]; then
+  IFS=';' read -ra REPO_ENTRIES <<< "$RETRIEVE_GIT_REPOS"
+  for entry in "${REPO_ENTRIES[@]}"; do
+    REPO_NAME="${entry%%:*}"
+    REPO_PATH="${entry#*:}"
+    if [ -z "$REPO_NAME" ] || [ -z "$REPO_PATH" ]; then
+      echo "$LOG_PREFIX Warning: skipping malformed git repo entry '$entry' (expected name:path)"
+      continue
+    fi
+    if [ -d "$REPO_PATH/.git" ]; then
+      echo "$LOG_PREFIX Pulling latest $REPO_NAME..."
+      git -C "$REPO_PATH" pull --ff-only 2>&1 || echo "$LOG_PREFIX Warning: $REPO_NAME git pull failed"
+      echo "$LOG_PREFIX Indexing $REPO_NAME -> ${INDEX_PREFIX}${REPO_NAME}"
+      node src/cli.mjs index "$REPO_PATH" --name "${INDEX_PREFIX}${REPO_NAME}" 2>&1 || echo "$LOG_PREFIX Warning: $REPO_NAME indexing failed"
+    else
+      echo "$LOG_PREFIX Warning: $REPO_NAME path '$REPO_PATH' is not a git repo, skipping"
+    fi
+  done
 fi
 
 echo "$LOG_PREFIX Done"

--- a/scheduling/sync-and-index.sh
+++ b/scheduling/sync-and-index.sh
@@ -71,4 +71,13 @@ for adapter in slack notion linear; do
   fi
 done
 
+# Mono repo code index
+MONO_DIR="$HOME/code/mono"
+if [ -d "$MONO_DIR/.git" ]; then
+  echo "$LOG_PREFIX Pulling latest mono main..."
+  git -C "$MONO_DIR" pull --ff-only 2>&1 || echo "$LOG_PREFIX Warning: mono git pull failed"
+  echo "$LOG_PREFIX Indexing mono -> mono"
+  node src/cli.mjs index "$MONO_DIR" --name mono 2>&1 || echo "$LOG_PREFIX Warning: mono indexing failed"
+fi
+
 echo "$LOG_PREFIX Done"

--- a/scheduling/sync-and-index.sh
+++ b/scheduling/sync-and-index.sh
@@ -9,13 +9,15 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 LOCK_FILE="/tmp/retrieval-skill-sync.lock"
 LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')]"
 
-# Build PATH — last entry prepended wins, so mise shims must be last
+# Build PATH — last entry prepended wins, so it ends up first in $PATH.
+# /opt/homebrew/bin must be last so it takes priority (contains Node v25.x
+# that matches the compiled better-sqlite3 native module).
 for p in \
-  "/usr/local/bin" \
-  "/opt/homebrew/bin" \
-  "$HOME/.nvm/versions/node/"*/bin \
+  "$HOME/.local/share/mise/shims" \
   "$HOME/.local/bin" \
-  "$HOME/.local/share/mise/shims"; do
+  "$HOME/.nvm/versions/node/"*/bin \
+  "/usr/local/bin" \
+  "/opt/homebrew/bin"; do
   [ -d "$p" ] && export PATH="$p:$PATH"
 done
 

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -2,15 +2,15 @@
 
 import 'dotenv/config';
 
-import { existsSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { Command } from 'commander';
+import { existsSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { runDoctor } from './doctor.mjs';
 import { deleteIndex, getIndexStatus, indexDirectory, listIndexes, reindexAll, reindexByName } from './index.mjs';
-import { stackDown, stackUp } from './stack.mjs';
 import { formatResults, formatResultsJson, search } from './search.mjs';
+import { stackDown, stackUp } from './stack.mjs';
 import { indexPdfVision } from './vision-index.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -51,7 +51,7 @@ async function checkEmbeddingServer() {
       return { ok: true, msg: `Embedding server healthy at ${EMBEDDING_SERVER_URL}${extra}` };
     }
     return { ok: false, msg: `Embedding server status: ${status}` };
-  } catch (err) {
+  } catch (_err) {
     return { ok: false, msg: `Embedding server unreachable at ${EMBEDDING_SERVER_URL}` };
   }
 }

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -56,6 +56,29 @@ async function checkEmbeddingServer() {
   }
 }
 
+// ── Check 1b: Native module compatibility ──
+
+function checkNativeModules() {
+  try {
+    // Attempt to load better-sqlite3 via a subprocess — if the native module was
+    // compiled for a different Node version, it throws ERR_DLOPEN_FAILED.
+    execSync(
+      `node -e "require('better-sqlite3')"`,
+      { encoding: 'utf-8', timeout: 5000, stdio: 'pipe' }
+    );
+    return { ok: true, msg: `Native modules compatible (Node ${process.version}, MODULE_VERSION ${process.versions.modules})` };
+  } catch (err) {
+    const msg = (err.stderr || '') + (err.stdout || '') + (err.message || '');
+    if (msg.includes('NODE_MODULE_VERSION') || msg.includes('ERR_DLOPEN_FAILED')) {
+      return {
+        ok: false,
+        msg: `better-sqlite3 native module version mismatch — run: npm rebuild better-sqlite3\n       (Node ${process.version} MODULE_VERSION ${process.versions.modules})`,
+      };
+    }
+    return { ok: true, msg: `Native modules: could not verify (${err.message})` };
+  }
+}
+
 // ── Check 2: Connector credentials ──
 
 const CONNECTOR_VARS = {
@@ -168,6 +191,7 @@ export async function runDoctor() {
 
   const checks = [
     { name: 'Embedding server', fn: checkEmbeddingServer },
+    { name: 'Native modules', fn: checkNativeModules },
     { name: 'Connectors', fn: checkConnectorCredentials },
     { name: 'Indexes', fn: checkIndexFreshness },
     { name: 'Disk space', fn: checkDiskSpace },
@@ -175,7 +199,7 @@ export async function runDoctor() {
   ];
 
   let allCriticalOk = true;
-  const criticalChecks = new Set(['Embedding server', 'Connectors']);
+  const criticalChecks = new Set(['Embedding server', 'Connectors', 'Native modules']);
 
   for (const check of checks) {
     const result = await check.fn();

--- a/src/stack.mjs
+++ b/src/stack.mjs
@@ -87,10 +87,11 @@ export async function stackUp() {
       const venvActivate = join(OCTEN_SERVER_DIR, '.venv', 'bin', 'activate');
       if (existsSync(venvActivate)) {
         try {
-          execSync(
-            `cd "${OCTEN_SERVER_DIR}" && source .venv/bin/activate && python3 server.py &`,
-            { shell: '/bin/bash', stdio: 'ignore', detached: true },
-          );
+          execSync(`cd "${OCTEN_SERVER_DIR}" && source .venv/bin/activate && python3 server.py &`, {
+            shell: '/bin/bash',
+            stdio: 'ignore',
+            detached: true,
+          });
           log(`  Started server directly from ${OCTEN_SERVER_DIR}`);
         } catch {
           log(`  ${RED}Failed to start server from ${OCTEN_SERVER_DIR}${RESET}`);

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -1,41 +1,85 @@
 import { createHash } from 'crypto';
 import { readdir, readFile, stat } from 'fs/promises';
-import { basename, extname, join } from 'path';
+import { extname, join } from 'path';
 
 const INDEXED_EXTENSIONS = new Set([
   // Docs / prose
-  '.md', '.markdown', '.txt', '.mdx',
+  '.md',
+  '.markdown',
+  '.txt',
+  '.mdx',
   // TypeScript / JavaScript
-  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
   // Python
   '.py',
   // Config
-  '.yaml', '.yml', '.json', '.toml', '.env.example',
+  '.yaml',
+  '.yml',
+  '.json',
+  '.toml',
+  '.env.example',
   // Infrastructure
-  '.tf', '.hcl', '.sh', '.bash',
+  '.tf',
+  '.hcl',
+  '.sh',
+  '.bash',
   // Web
-  '.css', '.scss', '.html',
+  '.css',
+  '.scss',
+  '.html',
   // Database / API
-  '.prisma', '.graphql', '.gql', '.sql',
+  '.prisma',
+  '.graphql',
+  '.gql',
+  '.sql',
   // Other
-  '.xml', '.csv', '.ini', '.cfg', '.conf', '.properties',
+  '.xml',
+  '.csv',
+  '.ini',
+  '.cfg',
+  '.conf',
+  '.properties',
 ]);
 
 /** Extensionless filenames that should be indexed. */
 const INDEXED_FILENAMES = new Set([
-  'Dockerfile', 'Makefile', '.gitignore', '.dockerignore', '.eslintrc', '.prettierrc',
+  'Dockerfile',
+  'Makefile',
+  '.gitignore',
+  '.dockerignore',
+  '.eslintrc',
+  '.prettierrc',
 ]);
 
 /** Lock files to always skip. */
 const SKIPPED_FILENAMES = new Set([
-  'yarn.lock', 'package-lock.json', 'pnpm-lock.yaml', 'bun.lockb',
-  'Gemfile.lock', 'poetry.lock', 'composer.lock',
+  'yarn.lock',
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'bun.lockb',
+  'Gemfile.lock',
+  'poetry.lock',
+  'composer.lock',
 ]);
 
 /** Directories to skip during walk (in addition to _ and . prefixed dirs). */
 const SKIPPED_DIRS = new Set([
-  'node_modules', 'dist', 'build', '.next', '__generated__', 'generated',
-  'coverage', '.turbo', '.yarn', 'venv', '.venv',
+  'node_modules',
+  'dist',
+  'build',
+  '.next',
+  '__generated__',
+  'generated',
+  'coverage',
+  '.turbo',
+  '.yarn',
+  'venv',
+  '.venv',
 ]);
 
 /**

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -1,8 +1,42 @@
 import { createHash } from 'crypto';
 import { readdir, readFile, stat } from 'fs/promises';
-import { extname, join } from 'path';
+import { basename, extname, join } from 'path';
 
-const INDEXED_EXTENSIONS = new Set(['.md', '.markdown', '.txt']);
+const INDEXED_EXTENSIONS = new Set([
+  // Docs / prose
+  '.md', '.markdown', '.txt', '.mdx',
+  // TypeScript / JavaScript
+  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
+  // Python
+  '.py',
+  // Config
+  '.yaml', '.yml', '.json', '.toml', '.env.example',
+  // Infrastructure
+  '.tf', '.hcl', '.sh', '.bash',
+  // Web
+  '.css', '.scss', '.html',
+  // Database / API
+  '.prisma', '.graphql', '.gql', '.sql',
+  // Other
+  '.xml', '.csv', '.ini', '.cfg', '.conf', '.properties',
+]);
+
+/** Extensionless filenames that should be indexed. */
+const INDEXED_FILENAMES = new Set([
+  'Dockerfile', 'Makefile', '.gitignore', '.dockerignore', '.eslintrc', '.prettierrc',
+]);
+
+/** Lock files to always skip. */
+const SKIPPED_FILENAMES = new Set([
+  'yarn.lock', 'package-lock.json', 'pnpm-lock.yaml', 'bun.lockb',
+  'Gemfile.lock', 'poetry.lock', 'composer.lock',
+]);
+
+/** Directories to skip during walk (in addition to _ and . prefixed dirs). */
+const SKIPPED_DIRS = new Set([
+  'node_modules', 'dist', 'build', '.next', '__generated__', 'generated',
+  'coverage', '.turbo', '.yarn', 'venv', '.venv',
+]);
 
 /**
  * SHA-256 hash of a string, returned as hex.
@@ -40,10 +74,13 @@ async function _walk(dir, results) {
   for (const entry of entries) {
     const fullPath = join(dir, entry.name);
     if (entry.isDirectory()) {
-      // Skip metadata and hidden directories
-      if (entry.name.startsWith('_') || entry.name.startsWith('.')) continue;
+      if (entry.name.startsWith('_') || entry.name.startsWith('.') || SKIPPED_DIRS.has(entry.name)) continue;
       await _walk(fullPath, results);
-    } else if (entry.isFile() && INDEXED_EXTENSIONS.has(extname(entry.name).toLowerCase())) {
+    } else if (entry.isFile()) {
+      const name = entry.name;
+      if (SKIPPED_FILENAMES.has(name)) continue;
+      const isIndexable = INDEXED_EXTENSIONS.has(extname(name).toLowerCase()) || INDEXED_FILENAMES.has(name);
+      if (!isIndexable) continue;
       try {
         const s = await stat(fullPath);
         results.push({ path: fullPath, size: s.size, mtimeMs: s.mtimeMs });


### PR DESCRIPTION
## Summary
- Extend `INDEXED_EXTENSIONS` to cover common source code files (.ts, .tsx, .js, .py, .yaml, .json, .toml, .tf, .sql, .prisma, .graphql, etc.)
- Add support for extensionless config files (Dockerfile, Makefile, .gitignore, .dockerignore, .eslintrc, .prettierrc)
- Skip generated/vendor directories (node_modules, dist, build, .next, coverage, venv, .turbo, .yarn, __generated__)
- Skip lock files (yarn.lock, package-lock.json, pnpm-lock.yaml, etc.)
- Add mono repo pull + index step to `sync-and-index.sh`

## Test plan
- [x] `node src/cli.mjs list` still works
- [ ] `node src/cli.mjs index ~/code/mono --name mono` picks up source files, skips node_modules/dist/locks
- [ ] Verify file/chunk counts via `node src/cli.mjs status mono`

🤖 Generated with [Claude Code](https://claude.com/claude-code)