### PR TITLE
feat: per-index retry with backoff, embedding health check, daily-reindex + health-check CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,26 @@ Run as a long-lived daemon with periodic sync.
 | `--interval <minutes>` | Minutes between sync cycles | `15` |
 | `--output <dir>` | Output directory | `./data` |
 
+### Automated operations
+
+#### `retrieve daily-reindex`
+
+Reindex all four SaaS indexes (`slack`, `notion`, `linear`, `mono`) with per-index retry and exponential backoff. Each index gets an independent retry budget — a single index failing all attempts does not abort the others. Exits `0` if every index succeeded, `1` if any failed (making the cron DM condition trivial: `if exit≠0 DM Charlie`).
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--max-attempts <n>` | Max retry attempts per index | `3` |
+| `--indexes <list>` | Comma-separated index names | `slack,notion,linear,mono` |
+
+#### `retrieve health-check`
+
+Check the embedding server status and index staleness. Prints a JSON report of `{ server, indexes }`. With `--auto-fix`, automatically reindexes any stale index if the embedding server is healthy, then re-evaluates staleness. Exits `0` if everything is healthy or was successfully fixed; exits `1` if any index is stale and unfixable (server down) or if auto-fix failed.
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--threshold-hours <n>` | Staleness threshold in hours | `48` |
+| `--auto-fix` | Reindex stale indexes when server is healthy | off |
+
 ### Stack management
 
 #### `retrieve doctor`
@@ -370,6 +390,13 @@ Scheduler output goes to `/tmp/retrieval-skill-sync.log`:
 ```bash
 tail -f /tmp/retrieval-skill-sync.log
 ```
+
+### Cron migration
+
+The previous cron setup ran `node src/cli.mjs reindex slack && ... && reindex mono` in a single shell — if any index failed mid-chain, the shell exited non-zero but the cron system reported success because earlier indexes had already printed output. After merging this PR, replace both cron jobs in `~/.openclaw/cron/jobs.json` with one-liners that delegate to the new subcommands:
+
+- **Daily reindex job**: change the prompt/command to `node /path/to/retrieval-skill/src/cli.mjs daily-reindex` (or `retrieve daily-reindex` if globally linked). The command exits `1` if any index ultimately fails after all retries, so your cron system's "notify on non-zero exit" DM will fire correctly for partial failures.
+- **Health alarm job**: change to `node /path/to/retrieval-skill/src/cli.mjs health-check --threshold-hours 48 --auto-fix`. With `--auto-fix`, a stale index is automatically reindexed if the embedding server is healthy; the job only exits `1` (and DMs you) when the situation is genuinely unrecoverable (server down, or retries exhausted).
 
 ## Search scoring
 

--- a/__tests__/health.test.mjs
+++ b/__tests__/health.test.mjs
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { checkEmbeddingServer, getIndexStaleness } from '../src/health.mjs';
+
+vi.mock('../src/index.mjs', () => ({
+  listIndexes: vi.fn(),
+}));
+
+import { listIndexes } from '../src/index.mjs';
+
+describe('checkEmbeddingServer', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns ok:true with statusCode and optional fields on 200', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: 'ok', uptime_seconds: 3600, error_count: 0 }),
+      }),
+    );
+    const result = await checkEmbeddingServer({ url: 'http://localhost:8100' });
+    expect(result.ok).toBe(true);
+    expect(result.statusCode).toBe(200);
+    expect(result.uptimeSeconds).toBe(3600);
+    expect(result.errorCount).toBe(0);
+  });
+
+  it('returns ok:false with statusCode on 502', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 502,
+      }),
+    );
+    const result = await checkEmbeddingServer({ url: 'http://localhost:8100' });
+    expect(result.ok).toBe(false);
+    expect(result.statusCode).toBe(502);
+  });
+
+  it('returns ok:false with error on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+    const result = await checkEmbeddingServer({ url: 'http://localhost:8100' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/ECONNREFUSED/);
+  });
+
+  it('returns ok:false on timeout (AbortError)', async () => {
+    const err = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(err));
+    const result = await checkEmbeddingServer({ url: 'http://localhost:8100', timeoutMs: 100 });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('omits optional fields when not in response body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: 'ok' }),
+      }),
+    );
+    const result = await checkEmbeddingServer({ url: 'http://localhost:8100' });
+    expect(result.ok).toBe(true);
+    expect(result.uptimeSeconds).toBeUndefined();
+    expect(result.errorCount).toBeUndefined();
+  });
+});
+
+describe('getIndexStaleness', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('marks a recently indexed index as fresh', () => {
+    const now = new Date().toISOString();
+    listIndexes.mockReturnValue([{ name: 'slack', lastIndexedAt: now, totalFiles: '100', totalChunks: '500' }]);
+    const result = getIndexStaleness({ thresholdHours: 48 });
+    expect(result).toHaveLength(1);
+    expect(result[0].stale).toBe(false);
+    expect(result[0].ageHours).toBeLessThan(1);
+    expect(result[0].files).toBe(100);
+    expect(result[0].chunks).toBe(500);
+  });
+
+  it('marks an old index as stale', () => {
+    const old = new Date(Date.now() - 50 * 60 * 60 * 1000).toISOString();
+    listIndexes.mockReturnValue([{ name: 'mono', lastIndexedAt: old, totalFiles: '200', totalChunks: '1000' }]);
+    const result = getIndexStaleness({ thresholdHours: 48 });
+    expect(result[0].stale).toBe(true);
+    expect(result[0].ageHours).toBeGreaterThan(49);
+  });
+
+  it('marks an index with null lastIndexedAt as stale', () => {
+    listIndexes.mockReturnValue([{ name: 'notion', lastIndexedAt: null, totalFiles: '50', totalChunks: '200' }]);
+    const result = getIndexStaleness({ thresholdHours: 48 });
+    expect(result[0].stale).toBe(true);
+    expect(result[0].ageHours).toBeNull();
+    expect(result[0].lastIndexedAt).toBeNull();
+  });
+
+  it('handles a mix of fresh, stale, and missing timestamps', () => {
+    const fresh = new Date().toISOString();
+    const old = new Date(Date.now() - 100 * 60 * 60 * 1000).toISOString();
+    listIndexes.mockReturnValue([
+      { name: 'slack', lastIndexedAt: fresh, totalFiles: '100', totalChunks: '500' },
+      { name: 'mono', lastIndexedAt: old, totalFiles: '200', totalChunks: '1000' },
+      { name: 'notion', lastIndexedAt: null, totalFiles: null, totalChunks: null },
+    ]);
+    const result = getIndexStaleness({ thresholdHours: 48 });
+    expect(result[0].stale).toBe(false);
+    expect(result[1].stale).toBe(true);
+    expect(result[2].stale).toBe(true);
+  });
+
+  it('marks errored indexes as stale with null fields', () => {
+    listIndexes.mockReturnValue([{ name: 'linear', error: 'Could not read index' }]);
+    const result = getIndexStaleness({ thresholdHours: 48 });
+    expect(result[0].stale).toBe(true);
+    expect(result[0].lastIndexedAt).toBeNull();
+    expect(result[0].ageHours).toBeNull();
+    expect(result[0].files).toBeNull();
+    expect(result[0].chunks).toBeNull();
+  });
+
+  it('returns empty array when no indexes exist', () => {
+    listIndexes.mockReturnValue([]);
+    const result = getIndexStaleness({ thresholdHours: 48 });
+    expect(result).toHaveLength(0);
+  });
+});

--- a/__tests__/reindex-with-retry.test.mjs
+++ b/__tests__/reindex-with-retry.test.mjs
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { reindexAllWithRetry } from '../src/reindex-with-retry.mjs';
+
+vi.mock('../src/index.mjs', () => ({
+  reindexByName: vi.fn(),
+}));
+
+vi.mock('../src/health.mjs', () => ({
+  checkEmbeddingServer: vi.fn(),
+}));
+
+import { checkEmbeddingServer } from '../src/health.mjs';
+import { reindexByName } from '../src/index.mjs';
+
+describe('reindexAllWithRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    checkEmbeddingServer.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('all succeed on first attempt', async () => {
+    reindexByName.mockResolvedValue({ indexed: 10, skipped: 0 });
+    const promise = reindexAllWithRetry({
+      indexes: ['slack', 'notion'],
+      maxAttempts: 3,
+      backoffMs: [1000, 2000],
+      healthCheckBetweenAttempts: false,
+    });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+    expect(result.allOk).toBe(true);
+    expect(result.summary).toHaveLength(2);
+    expect(result.summary[0].status).toBe('ok');
+    expect(result.summary[0].attempts).toBe(1);
+    expect(result.summary[1].status).toBe('ok');
+    expect(result.summary[1].attempts).toBe(1);
+  });
+
+  it('retries on failure and succeeds on third attempt', async () => {
+    let calls = 0;
+    reindexByName.mockImplementation(async () => {
+      calls++;
+      if (calls < 3) throw new Error('temporary failure');
+      return { indexed: 5 };
+    });
+    const promise = reindexAllWithRetry({
+      indexes: ['mono'],
+      maxAttempts: 3,
+      backoffMs: [100, 200],
+      healthCheckBetweenAttempts: false,
+    });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+    expect(result.allOk).toBe(true);
+    expect(result.summary[0].status).toBe('ok');
+    expect(result.summary[0].attempts).toBe(3);
+  });
+
+  it('marks index as failed after exhausting all attempts', async () => {
+    reindexByName.mockRejectedValue(new Error('persistent failure'));
+    const promise = reindexAllWithRetry({
+      indexes: ['mono'],
+      maxAttempts: 3,
+      backoffMs: [100, 200],
+      healthCheckBetweenAttempts: false,
+    });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+    expect(result.allOk).toBe(false);
+    expect(result.summary[0].status).toBe('failed');
+    expect(result.summary[0].attempts).toBe(3);
+    expect(result.summary[0].error).toBe('persistent failure');
+  });
+
+  it('independent retry budget: one fails all attempts while others succeed', async () => {
+    reindexByName.mockImplementation(async (name) => {
+      if (name === 'mono') throw new Error('mono broken');
+      return { indexed: 5 };
+    });
+    const promise = reindexAllWithRetry({
+      indexes: ['slack', 'mono', 'notion'],
+      maxAttempts: 2,
+      backoffMs: [100],
+      healthCheckBetweenAttempts: false,
+    });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+    expect(result.allOk).toBe(false);
+    const slack = result.summary.find((s) => s.name === 'slack');
+    const mono = result.summary.find((s) => s.name === 'mono');
+    const notion = result.summary.find((s) => s.name === 'notion');
+    expect(slack.status).toBe('ok');
+    expect(mono.status).toBe('failed');
+    expect(notion.status).toBe('ok');
+  });
+
+  it('detects provider-failover-502 error message and records it', async () => {
+    reindexByName.mockRejectedValue(new Error('all providers in failover chain failed: 502 Bad Gateway'));
+    const promise = reindexAllWithRetry({
+      indexes: ['mono'],
+      maxAttempts: 2,
+      backoffMs: [100],
+      healthCheckBetweenAttempts: false,
+    });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+    expect(result.allOk).toBe(false);
+    expect(result.summary[0].error).toMatch(/502|failover/i);
+  });
+
+  it('aborts remaining retries when embedding server is unhealthy between attempts', async () => {
+    reindexByName.mockImplementation(async () => {
+      throw new Error('server error');
+    });
+    checkEmbeddingServer.mockResolvedValue({ ok: false });
+    const promise = reindexAllWithRetry({
+      indexes: ['mono'],
+      maxAttempts: 3,
+      backoffMs: [100, 200],
+      healthCheckBetweenAttempts: true,
+    });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+    expect(result.allOk).toBe(false);
+    // 1 attempt: first fails, health check runs after sleep, health is bad → abort before attempt 2
+    expect(result.summary[0].attempts).toBe(1);
+  });
+
+  it('summary entries are JSON-serializable', async () => {
+    reindexByName.mockResolvedValue({ indexed: 1 });
+    const promise = reindexAllWithRetry({
+      indexes: ['slack'],
+      maxAttempts: 1,
+      backoffMs: [],
+      healthCheckBetweenAttempts: false,
+    });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it('allOk is true only when every index succeeds', async () => {
+    reindexByName.mockImplementation(async (name) => {
+      if (name === 'linear') throw new Error('linear failed');
+      return {};
+    });
+    const promise = reindexAllWithRetry({
+      indexes: ['slack', 'linear'],
+      maxAttempts: 1,
+      backoffMs: [],
+      healthCheckBetweenAttempts: false,
+    });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+    expect(result.allOk).toBe(false);
+  });
+});

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -2,15 +2,17 @@
 
 import 'dotenv/config';
 
-import { existsSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { Command } from 'commander';
+import { existsSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { runDoctor } from './doctor.mjs';
+import { checkEmbeddingServer, getIndexStaleness } from './health.mjs';
 import { deleteIndex, getIndexStatus, indexDirectory, listIndexes, reindexAll, reindexByName } from './index.mjs';
-import { stackDown, stackUp } from './stack.mjs';
+import { reindexAllWithRetry } from './reindex-with-retry.mjs';
 import { formatResults, formatResultsJson, search } from './search.mjs';
+import { stackDown, stackUp } from './stack.mjs';
 import { indexPdfVision } from './vision-index.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -251,6 +253,55 @@ mirror
   .option('--output <dir>', 'Output directory', './data')
   .action((opts) => {
     runMirrorCli(['daemon', '--interval', opts.interval, '--output', opts.output]);
+  });
+
+// ─── Automated ops ───
+
+program
+  .command('daily-reindex')
+  .description('Reindex all indexes with per-index retry and exponential backoff')
+  .option('--max-attempts <n>', 'Max retry attempts per index', '3')
+  .option('--indexes <list>', 'Comma-separated index names', 'slack,notion,linear,mono')
+  .action(async (opts) => {
+    const indexes = opts.indexes.split(',').map((s) => s.trim());
+    const maxAttempts = parseInt(opts.maxAttempts, 10);
+    const result = await reindexAllWithRetry({ indexes, maxAttempts });
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(result.allOk ? 0 : 1);
+  });
+
+program
+  .command('health-check')
+  .description('Check embedding server health and index staleness')
+  .option('--threshold-hours <n>', 'Staleness threshold in hours', '48')
+  .option('--auto-fix', 'Reindex stale indexes when embedding server is healthy')
+  .action(async (opts) => {
+    const thresholdHours = parseFloat(opts.thresholdHours);
+    const server = await checkEmbeddingServer();
+    const indexes = getIndexStaleness({ thresholdHours });
+    const result = { server, indexes, autoFix: null };
+
+    const staleIndexes = indexes.filter((i) => i.stale);
+    const allHealthy = server.ok && staleIndexes.length === 0;
+
+    if (allHealthy || !opts.autoFix) {
+      console.log(JSON.stringify(result, null, 2));
+      process.exit(allHealthy ? 0 : 1);
+      return;
+    }
+
+    if (!server.ok) {
+      result.autoFix = { skipped: true, reason: 'embedding server unhealthy' };
+      console.log(JSON.stringify(result, null, 2));
+      process.exit(1);
+      return;
+    }
+
+    const fix = await reindexAllWithRetry({ indexes: staleIndexes.map((i) => i.name) });
+    result.autoFix = fix;
+    result.indexes = getIndexStaleness({ thresholdHours });
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(fix.allOk ? 0 : 1);
   });
 
 program.parse();

--- a/src/health.mjs
+++ b/src/health.mjs
@@ -1,0 +1,53 @@
+import { listIndexes } from './index.mjs';
+
+export async function checkEmbeddingServer({
+  url = process.env.EMBEDDING_SERVER_URL || 'http://localhost:8100',
+  timeoutMs = 5000,
+} = {}) {
+  try {
+    const res = await fetch(`${url}/health`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) {
+      return { ok: false, statusCode: res.status };
+    }
+    let data = {};
+    try {
+      data = await res.json();
+    } catch {
+      // non-JSON body is fine
+    }
+    const result = { ok: true, statusCode: res.status };
+    if (data.uptime_seconds != null) result.uptimeSeconds = data.uptime_seconds;
+    if (data.error_count != null) result.errorCount = data.error_count;
+    return result;
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+}
+
+export function getIndexStaleness({ thresholdHours = 48 } = {}) {
+  const indexes = listIndexes();
+  const now = Date.now();
+  return indexes.map((idx) => {
+    if (idx.error) {
+      return { name: idx.name, lastIndexedAt: null, ageHours: null, stale: true, files: null, chunks: null };
+    }
+    const lastIndexedAt = idx.lastIndexedAt || null;
+    let ageHours = null;
+    let stale = true;
+    if (lastIndexedAt) {
+      const ms = now - new Date(lastIndexedAt).getTime();
+      ageHours = Math.round((ms / (1000 * 60 * 60)) * 10) / 10;
+      stale = ageHours > thresholdHours;
+    }
+    return {
+      name: idx.name,
+      lastIndexedAt,
+      ageHours,
+      stale,
+      files: idx.totalFiles != null ? parseInt(idx.totalFiles, 10) : null,
+      chunks: idx.totalChunks != null ? parseInt(idx.totalChunks, 10) : null,
+    };
+  });
+}

--- a/src/reindex-with-retry.mjs
+++ b/src/reindex-with-retry.mjs
@@ -1,0 +1,56 @@
+import { checkEmbeddingServer } from './health.mjs';
+import { reindexByName } from './index.mjs';
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function reindexAllWithRetry({
+  indexes = ['slack', 'notion', 'linear', 'mono'],
+  maxAttempts = 3,
+  backoffMs = [30_000, 120_000, 300_000],
+  healthCheckBetweenAttempts = true,
+} = {}) {
+  const summary = [];
+
+  for (const name of indexes) {
+    const start = Date.now();
+    let lastError = null;
+    let attempts = 0;
+    let status = 'failed';
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      attempts = attempt;
+      try {
+        await reindexByName(name);
+        status = 'ok';
+        lastError = null;
+        break;
+      } catch (err) {
+        lastError = err;
+        console.error(`[retry] ${name} attempt ${attempt}/${maxAttempts} failed: ${err.message}`);
+
+        if (attempt < maxAttempts) {
+          const delay = backoffMs[attempt - 1] ?? backoffMs[backoffMs.length - 1] ?? 30_000;
+          console.error(`[retry] waiting ${delay}ms before retry...`);
+          await sleep(delay);
+
+          if (healthCheckBetweenAttempts) {
+            const health = await checkEmbeddingServer();
+            if (!health.ok) {
+              console.error(`[retry] embedding server unhealthy, aborting retries for ${name}`);
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    const entry = { name, status, attempts, durationMs: Date.now() - start };
+    if (lastError) entry.error = lastError.message;
+    summary.push(entry);
+  }
+
+  const allOk = summary.every((s) => s.status === 'ok');
+  return { summary, allOk };
+}

--- a/src/stack.mjs
+++ b/src/stack.mjs
@@ -87,10 +87,11 @@ export async function stackUp() {
       const venvActivate = join(OCTEN_SERVER_DIR, '.venv', 'bin', 'activate');
       if (existsSync(venvActivate)) {
         try {
-          execSync(
-            `cd "${OCTEN_SERVER_DIR}" && source .venv/bin/activate && python3 server.py &`,
-            { shell: '/bin/bash', stdio: 'ignore', detached: true },
-          );
+          execSync(`cd "${OCTEN_SERVER_DIR}" && source .venv/bin/activate && python3 server.py &`, {
+            shell: '/bin/bash',
+            stdio: 'ignore',
+            detached: true,
+          });
           log(`  Started server directly from ${OCTEN_SERVER_DIR}`);
         } catch {
           log(`  ${RED}Failed to start server from ${OCTEN_SERVER_DIR}${RESET}`);


### PR DESCRIPTION
## Incident Summary

On 2026-05-19 at 10:11am, the embedding server (localhost:8100, Octen-8B via Ohm proxy) was running for 8+ hours but failed mid-run during mono reindex at chunk 127/4794 with `all providers in failover chain failed: 502 Bad Gateway`. Two systemic bugs surfaced:

1. **Silent partial failure**: The daily reindex cron ran `reindex slack && reindex notion && reindex linear && reindex mono` as a single `&&` chain. When mono failed, the cron job still reported success because earlier indexes had already exited 0. Charlie was never DM'd; mono sat stale until the 8am health alarm.

2. **Health alarm has no teeth**: The 8am alarm only DMs when an index is >48h old. It doesn't check whether the embedding server is up, doesn't retry, and doesn't auto-fix anything.

## Design

### New modules (additive only — no existing functions modified)

**`src/health.mjs`**
- `checkEmbeddingServer({ url, timeoutMs })` — GET /health → `{ ok, statusCode?, uptimeSeconds?, errorCount?, error? }`. Any non-2xx, network error, or timeout → `ok: false`.
- `getIndexStaleness({ thresholdHours })` — reads `listIndexes()` metadata → per-index `{ name, lastIndexedAt, ageHours, stale, files, chunks }`.

**`src/reindex-with-retry.mjs`**
- `reindexAllWithRetry({ indexes, maxAttempts, backoffMs, healthCheckBetweenAttempts })` — independent retry budget per index. On failure: wait backoff, optionally check `/health` (abort that index's retries if server is down), then retry. Returns `{ summary: [{ name, status, attempts, durationMs, error? }], allOk }`.

### New CLI subcommands

**`retrieve daily-reindex`** — runs `reindexAllWithRetry()`, prints JSON summary to stdout. Exit 0 = all ok after retries; exit 1 = any failed. Flags: `--max-attempts <n>` (default 3), `--indexes <comma-list>` (default `slack,notion,linear,mono`)

**`retrieve health-check`** — checks server + staleness, prints JSON. With `--auto-fix`: reindexes stale indexes if server is healthy, then re-evaluates. Exit 0 = healthy or fixed; exit 1 = stale + unfixable or fix failed. Flags: `--threshold-hours <n>` (default 48), `--auto-fix`

## Exit Code Semantics

| Command | Exit 0 | Exit 1 |
|---------|--------|--------|
| `daily-reindex` | all indexes ok (with retries) | any index failed all attempts |
| `health-check` | all healthy OR auto-fix succeeded | stale + server down, OR auto-fix failed |

## Cron Migration Steps

After merge, update `~/.openclaw/cron/jobs.json`:

**Daily reindex job** — replace:
```
node /path/retrieval-skill/src/cli.mjs reindex slack && node ... reindex notion && node ... reindex linear && node ... reindex mono
```
with:
```
node /path/retrieval-skill/src/cli.mjs daily-reindex
```
Set the cron's "notify on non-zero exit" to DM Charlie. Exit 1 = at least one index failed after 3 attempts.

**Health alarm job** — replace the staleness-only check with:
```
node /path/retrieval-skill/src/cli.mjs health-check --threshold-hours 48 --auto-fix
```
Self-heals when server is up; DMs only when truly unrecoverable.

## E2E Evidence

### `node src/cli.mjs health-check --threshold-hours 1`

```json
{
  "server": { "ok": true, "statusCode": 200, "uptimeSeconds": 743 },
  "indexes": [
    { "name": "linear", "lastIndexedAt": "2026-05-19T09:03:14.902Z", "ageHours": 8.6, "stale": true, "files": 7466, "chunks": 28971 },
    { "name": "mono",   "lastIndexedAt": "2026-05-14T09:06:49.837Z", "ageHours": 128.5, "stale": true, "files": 4382, "chunks": 27800 },
    { "name": "notion", "lastIndexedAt": "2026-05-19T09:01:44.628Z", "ageHours": 8.6, "stale": true, "files": 9497, "chunks": 31890 },
    { "name": "slack",  "lastIndexedAt": "2026-05-19T09:01:17.382Z", "ageHours": 8.6, "stale": true, "files": 16414, "chunks": 37196 }
  ],
  "autoFix": null
}
```
Exit code: `1` (all stale vs 1h threshold). Server healthy — `--auto-fix` would have triggered reindex.

### `node src/cli.mjs daily-reindex --indexes slack`

This run hit the exact production 502 that prompted this PR:

```
Scanning .../data/slack... Found 15785 files. Pruned 689 deleted.
Progress: 1 indexed, 0 skipped / 15785 total
[retry] slack attempt 1/3 failed: Embedding server error (502): {"error":{"message":"all providers in failover chain failed","type":"all_providers_failed"}}
[retry] waiting 30000ms before retry...
[retry] embedding server unhealthy, aborting retries for slack
{
  "summary": [{ "name": "slack", "status": "failed", "attempts": 1, "durationMs": 707374,
    "error": "Embedding server error (502): ...all providers in failover chain failed..." }],
  "allOk": false
}
```
Exit code: `1` — 502 caught, retry attempted, health check confirmed server down, remaining retries aborted. With the new cron wiring, this would have DM'd Charlie immediately this morning.

> Note: Full mono reindex skipped per QA spec — embedding server intermittently failing. Retry/abort logic covered by unit tests.

### Vitest summary

```
Test Files  27 passed (27)
     Tests  589 passed | 4 skipped (593)
  Duration  4.16s
```

New test files:
- `__tests__/health.test.mjs` — 11 tests (checkEmbeddingServer × 5, getIndexStaleness × 6)
- `__tests__/reindex-with-retry.test.mjs` — 8 tests (all succeed, retry-then-succeed, exhaust attempts, independent budgets, 502 detection, health abort, serialization, allOk semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)